### PR TITLE
Fix selection of cwd for elm-make process

### DIFF
--- a/lib/linter-elm-make.js
+++ b/lib/linter-elm-make.js
@@ -1,6 +1,7 @@
 "use babel";
 
 const BufferedProcess = require('atom').BufferedProcess;
+const path = require('path');
 
 module.exports = {
   config: {
@@ -33,10 +34,21 @@ module.exports = {
           const filePath = textEditor.getPath();
           const lines = [];
           const executablePath = atom.config.get('linter-elm-make.elmMakeExecutablePath');
+
+          // make sure to use project of the current file
+          var cwd = undefined;
+          for (var projectPath in atom.project.getPaths()) {
+              if (textEditor.getPath().startsWith(projectPath)) {
+                  cwd = projectPath;
+                  break;
+              }
+          }
+
           const options = {
-            cwd: atom.project.getPaths()[0],
+            cwd: cwd || path.dirname(filePath),
             env: proc.env
           };
+
           const process = new BufferedProcess({
             command: executablePath,
             args: [filePath, '--warn', '--report=json', '--output=/dev/null'],


### PR DESCRIPTION
Use the project path for the current file rather than just the first one.

_Side note:_ it might make sense to use a more elaborate lookup mechanism, e.g., iterativing through the parent directories until one is found containing an `elm-stuff` dir or `elm-package.json` file.
