### PR TITLE
Quick Fix: Act on compiler messages

### DIFF
--- a/lib/linter-elm-make.js
+++ b/lib/linter-elm-make.js
@@ -225,7 +225,7 @@ function getFixesForProblem(problem, rangeText) {
   var matches = null;
   switch (problem.tag) {
     case 'NAMING ERROR':
-      if (!problem.suggestions) {
+      if (!problem.suggestions || problem.suggestions.length === 0) {
         return null;
       }
       matches = problem.details.match(/`(.*)` does not expose (.*). Maybe you want one of the following\?\n\n((.|\n)*)$/);
@@ -238,6 +238,15 @@ function getFixesForProblem(problem, rangeText) {
         });
       }
       matches = problem.details.match(/The qualifier `(.*)` is not in scope. Maybe you want one of the following\?\n\n((.|\n)*)$/);
+      if (matches) {
+        return problem.suggestions.map((suggestion) => {
+          return {
+            type: 'Replace with',
+            text: rangeText.replace(matches[1], suggestion)
+          };
+        });
+      }
+      matches = problem.overview.match(/^Cannot find type `(.*)`$/);
       if (matches) {
         return problem.suggestions.map((suggestion) => {
           return {

--- a/lib/linter-elm-make.js
+++ b/lib/linter-elm-make.js
@@ -25,7 +25,7 @@ module.exports = {
         detail: 'Please install the `linter` package in your Settings view'
       });
     }
-    module.exports.fixesByRange = [];
+    module.exports.quickFixes = {};
     module.exports.quickFixView = new QuickFixView();
     module.exports.quickFixView.onDidConfirm(({textEditor, range, fix}) => {
       fixProblem(textEditor, range, fix);
@@ -45,8 +45,7 @@ module.exports = {
     var fixesForPosition = null;
     const BreakException = {};
     try {
-      module.exports.fixesByRange
-      .filter(({filePath}) => { return textEditorPath === filePath; })
+      module.exports.quickFixes[textEditor.getPath()]
       .forEach(({range, fixes}) => {
         if (range.containsPoint(position)) {
           // Fix found! Get out of loop.
@@ -59,6 +58,9 @@ module.exports = {
     }
     if (fixesForPosition) {
       module.exports.quickFixView.show(textEditor, fixesForPosition.range, fixesForPosition.fixes);
+    } else {
+      atom.beep();
+      atom.notifications.addError('No quick fixes found.');
     }
   },
   provideLinter() {
@@ -109,27 +111,27 @@ module.exports = {
                         .split(" `").join(" `<span style='font-weight:bold'>")
                         .split("` ").join("</span>` ");
                     });
+                    const range = new Range(
+                      [problem.region.start.line - 1, problem.region.start.column - 1],
+                      [problem.region.end.line - 1, problem.region.end.column - 1]
+                    );
                     return {
                       type: problem.type,
                       html: `${colorize(problem.overview)}<br/><br/>${colorize(problem.details.split('\n').join('<br/>&nbsp;'))}`,
                       filePath: problem.file || filePath,
-                      range: new Range(
-                        [problem.region.start.line - 1, problem.region.start.column - 1],
-                        [problem.region.end.line - 1, problem.region.end.column - 1]
-                      ),
-                      fixes: getFixesForProblem(problem)
+                      range: range,
+                      fixes: getFixesForProblem(problem, textEditor.getTextInBufferRange(range))
                     };
                   });
                 }
               });
               const allProblems = [].concat.apply([], problemsByLine);
-              // Naive implementation. Just stores fixes in an array.
-              module.exports.fixesByRange =
+              // Naive implementation.
+              module.exports.quickFixes[filePath] =
                 allProblems
                 .filter(({fixes}) => { return fixes !== null; })
                 .map(({filePath, range, fixes}) => {
                   return {
-                    filePath: filePath,
                     range: range,
                     fixes: fixes
                   };
@@ -202,7 +204,8 @@ function lookupElmPackage(directory) {
   }
 }
 
-function getFixesForProblem(problem) {
+function getFixesForProblem(problem, rangeText) {
+  var matches = null;
   switch (problem.tag) {
     case 'NAMING ERROR':
       if (!problem.suggestions) {
@@ -210,7 +213,7 @@ function getFixesForProblem(problem) {
       }
       return problem.suggestions.map((suggestion) => {
         return {
-          type: 'Replace',
+          type: 'Replace with',
           text: suggestion
         };
       });
@@ -219,24 +222,55 @@ function getFixesForProblem(problem) {
         type: 'Add type annotation',
         text: problem.details.match(/I inferred the type annotation so you can copy it into your code:\n\n(.*)$/)[1]
       }];
+    case 'TYPE MISMATCH':
+      matches = problem.details.match(/But I am inferring that the definition has this type:\n\n    (.*)\n\nHint: A type annotation is too generic\. You can probably just switch to the type\nI inferred\. These issues can be subtle though, so read more about it\.\n<https:\/\/github\.com\/elm-lang\/elm-compiler\/blob\/0\.16\.0\/hints\/type-annotations\.md>$/);
+      if (matches) {
+        return [{
+          type: 'Replace with',
+          text: matches[1]
+        }];
+      } else if (problem.details === "(+) is expecting the left argument to be a:\n\n    number\n\nBut the left argument is:\n\n    String\n\nHint: To append strings in Elm, you need to use the (++) operator, not (+).\n<http://package.elm-lang.org/packages/elm-lang/core/latest/Basics#++>") {
+        return [{
+          type: 'Replace with',
+          text: rangeText.replace(/\+/, '++')
+        }];
+      }
+      return null;
+    case 'ALIAS PROBLEM':
+      matches = problem.details.match(/Try this instead:\n\n((.|\n)*)\n\nThis is kind of a subtle distinction\. I suggested the naive fix, but you can\noften do something a bit nicer\. So I would recommend reading more at:\n<https:\/\/github\.com\/elm-lang\/elm-compiler\/blob\/0\.16\.0\/hints\/recursive-alias\.md>$/);
+      if (matches) {
+        return [{
+          type: 'Replace with',
+          text: matches[1].split('\n').map((line) => {
+            return line.slice(4);
+          }).join('\n')
+        }];
+      }
+      return null;
+    case 'unused import':
+      // matches = problem.overview.match(/^Module `(.*)` is unused.$/);
+      return [{
+        type: 'Remove unused import',
+        // text: matches[1]
+        text: rangeText
+      }];
     default:
-      console.error('Unhandled tag: ' + problem.tag);
       return null;
   }
 }
 
 function fixProblem(textEditor, range, fix) {
   switch (fix.type) {
-    case 'Replace':
+    case 'Replace with':
       textEditor.setTextInBufferRange(range, fix.text);
       break;
     case 'Add type annotation':
       // Insert type annotation above the line.
-      textEditor.transact(() => {
-        textEditor.setCursorBufferPosition(range.start);
-        const leadingSpaces = new Array(range.start.column).join(' ');
-        textEditor.insertText(fix.text + '\n' + leadingSpaces);
-      });
+      const leadingSpaces = new Array(range.start.column).join(' ');
+      textEditor.setTextInBufferRange([range.start, range.start], fix.text + '\n' + leadingSpaces);
+      break;
+    case 'Remove unused import':
+      textEditor.buffer.deleteRow(range.start.row);
       break;
   }
 }

--- a/lib/linter-elm-make.js
+++ b/lib/linter-elm-make.js
@@ -70,11 +70,11 @@ module.exports = {
     textEditor.transact(() => {
       module.exports.quickFixes[textEditor.getPath()].forEach(({range, fixes}) => {
         marker = textEditor.markBufferRange(range, {invalidate: 'never', persistent: false});
-        marker.fixes = fixes;
+        marker.setProperties({fixes: fixes});
         markers.push(marker);
       });
       markers.forEach((marker) => {
-        fixProblem(textEditor, marker.getBufferRange(), marker.fixes[0]);
+        fixProblem(textEditor, marker.getBufferRange(), marker.getProperties().fixes[0]);
         marker.destroy();
       });
       markers = null;

--- a/lib/linter-elm-make.js
+++ b/lib/linter-elm-make.js
@@ -1,6 +1,8 @@
 "use babel";
 
+const QuickFixView = require('./quick-fix-view');
 const BufferedProcess = require('atom').BufferedProcess;
+const Range = require('atom').Range;
 const path = require("path");
 const fs = require("fs");
 
@@ -22,6 +24,41 @@ module.exports = {
       atom.notifications.addError('The linter package not found.', {
         detail: 'Please install the `linter` package in your Settings view'
       });
+    }
+    module.exports.fixesByRange = [];
+    module.exports.quickFixView = new QuickFixView();
+    module.exports.quickFixView.onDidConfirm(({textEditor, range, fix}) => {
+      fixProblem(textEditor, range, fix);
+    });
+    atom.commands.add('atom-text-editor', {
+      'linter-elm-make:quick-fix': module.exports.quickFix
+    });
+  },
+  deactivate() {
+    module.exports.quickFixView.destroy();
+  },
+  quickFix() {
+    var textEditor = atom.workspace.getActiveTextEditor();
+    const textEditorPath = textEditor.getPath();
+    const position = textEditor.getLastCursor().getBufferPosition();
+    // Look for fixes for the issue at cursor position.
+    var fixesForPosition = null;
+    const BreakException = {};
+    try {
+      module.exports.fixesByRange
+      .filter(({filePath}) => { return textEditorPath === filePath; })
+      .forEach(({range, fixes}) => {
+        if (range.containsPoint(position)) {
+          // Fix found! Get out of loop.
+          fixesForPosition = {range, fixes};
+          throw BreakException;
+        }
+      });
+    } catch(e) {
+      if (e!==BreakException) throw e;
+    }
+    if (fixesForPosition) {
+      module.exports.quickFixView.show(textEditor, fixesForPosition.range, fixesForPosition.fixes);
     }
   },
   provideLinter() {
@@ -76,15 +113,27 @@ module.exports = {
                       type: problem.type,
                       html: `${colorize(problem.overview)}<br/><br/>${colorize(problem.details.split('\n').join('<br/>&nbsp;'))}`,
                       filePath: problem.file || filePath,
-                      range: [
+                      range: new Range(
                         [problem.region.start.line - 1, problem.region.start.column - 1],
                         [problem.region.end.line - 1, problem.region.end.column - 1]
-                      ]
+                      ),
+                      fixes: getFixesForProblem(problem)
                     };
                   });
                 }
               });
               const allProblems = [].concat.apply([], problemsByLine);
+              // Naive implementation. Just stores fixes in an array.
+              module.exports.fixesByRange =
+                allProblems
+                .filter(({fixes}) => { return fixes !== null; })
+                .map(({filePath, range, fixes}) => {
+                  return {
+                    filePath: filePath,
+                    range: range,
+                    fixes: fixes
+                  };
+                });
               resolve(allProblems);
               progressIndicator.destroy();
             },
@@ -150,5 +199,44 @@ function lookupElmPackage(directory) {
     } else {
       return lookupElmPackage(parentDirectory);
     }
+  }
+}
+
+function getFixesForProblem(problem) {
+  switch (problem.tag) {
+    case 'NAMING ERROR':
+      if (!problem.suggestions) {
+        return null;
+      }
+      return problem.suggestions.map((suggestion) => {
+        return {
+          type: 'Replace',
+          text: suggestion
+        };
+      });
+    case 'missing type annotation':
+      return [{
+        type: 'Add type annotation',
+        text: problem.details.match(/I inferred the type annotation so you can copy it into your code:\n\n(.*)$/)[1]
+      }];
+    default:
+      console.error('Unhandled problem tag: ' + problem.tag);
+      return null;
+  }
+}
+
+function fixProblem(textEditor, range, fix) {
+  switch (fix.type) {
+    case 'Replace':
+      textEditor.setTextInBufferRange(range, fix.text);
+      break;
+    case 'Add type annotation':
+      // Insert type annotation above the line.
+      textEditor.transact(() => {
+        textEditor.setCursorBufferPosition(range.start);
+        const leadingSpaces = new Array(range.start.column).join(' ');
+        textEditor.insertText(fix.text + '\n' + leadingSpaces);
+      });
+      break;
   }
 }

--- a/lib/linter-elm-make.js
+++ b/lib/linter-elm-make.js
@@ -228,6 +228,24 @@ function getFixesForProblem(problem, rangeText) {
       if (!problem.suggestions) {
         return null;
       }
+      matches = problem.details.match(/`(.*)` does not expose (.*). Maybe you want one of the following\?\n\n((.|\n)*)$/);
+      if (matches) {
+        return problem.suggestions.map((suggestion) => {
+          return {
+            type: 'Replace with',
+            text: matches[1] + '.' + suggestion
+          };
+        });
+      }
+      matches = problem.details.match(/The qualifier `(.*)` is not in scope. Maybe you want one of the following\?\n\n((.|\n)*)$/);
+      if (matches) {
+        return problem.suggestions.map((suggestion) => {
+          return {
+            type: 'Replace with',
+            text: rangeText.replace(matches[1], suggestion)
+          };
+        });
+      }
       return problem.suggestions.map((suggestion) => {
         return {
           type: 'Replace with',

--- a/lib/linter-elm-make.js
+++ b/lib/linter-elm-make.js
@@ -45,8 +45,7 @@ module.exports = {
     var fixesForPosition = null;
     const BreakException = {};
     try {
-      module.exports.quickFixes[textEditor.getPath()]
-      .forEach(({range, fixes}) => {
+      module.exports.quickFixes[textEditor.getPath()].forEach(({range, fixes}) => {
         if (range.containsPoint(position)) {
           // Fix found! Get out of loop.
           fixesForPosition = {range, fixes};

--- a/lib/linter-elm-make.js
+++ b/lib/linter-elm-make.js
@@ -31,7 +31,8 @@ module.exports = {
       fixProblem(textEditor, range, fix);
     });
     atom.commands.add('atom-text-editor', {
-      'linter-elm-make:quick-fix': module.exports.quickFix
+      'linter-elm-make:quick-fix': module.exports.quickFix,
+      'linter-elm-make:quick-fix-all': module.exports.quickFixAll
     });
   },
   deactivate() {
@@ -61,6 +62,23 @@ module.exports = {
       atom.beep();
       atom.notifications.addError('No quick fixes found.');
     }
+  },
+  quickFixAll() {
+    var textEditor = atom.workspace.getActiveTextEditor();
+    var marker = null;
+    var markers = [];
+    textEditor.transact(() => {
+      module.exports.quickFixes[textEditor.getPath()].forEach(({range, fixes}) => {
+        marker = textEditor.markBufferRange(range, {invalidate: 'never', persistent: false});
+        marker.fixes = fixes;
+        markers.push(marker);
+      });
+      markers.forEach((marker) => {
+        fixProblem(textEditor, marker.getBufferRange(), marker.fixes[0]);
+        marker.destroy();
+      });
+      markers = null;
+    });
   },
   provideLinter() {
     const proc = process;

--- a/lib/linter-elm-make.js
+++ b/lib/linter-elm-make.js
@@ -229,7 +229,7 @@ function getFixesForProblem(problem, rangeText) {
         return null;
       }
       matches = problem.details.match(/`(.*)` does not expose (.*). Maybe you want one of the following\?\n\n((.|\n)*)$/);
-      if (matches) {
+      if (matches && matches.length > 1) {
         return problem.suggestions.map((suggestion) => {
           return {
             type: 'Replace with',
@@ -238,7 +238,7 @@ function getFixesForProblem(problem, rangeText) {
         });
       }
       matches = problem.details.match(/The qualifier `(.*)` is not in scope. Maybe you want one of the following\?\n\n((.|\n)*)$/);
-      if (matches) {
+      if (matches && matches.length > 1) {
         return problem.suggestions.map((suggestion) => {
           return {
             type: 'Replace with',
@@ -247,7 +247,7 @@ function getFixesForProblem(problem, rangeText) {
         });
       }
       matches = problem.overview.match(/^Cannot find type `(.*)`$/);
-      if (matches) {
+      if (matches && matches.length > 1) {
         return problem.suggestions.map((suggestion) => {
           return {
             type: 'Replace with',
@@ -262,13 +262,18 @@ function getFixesForProblem(problem, rangeText) {
         };
       });
     case 'missing type annotation':
-      return [{
-        type: 'Add type annotation',
-        text: problem.details.match(/I inferred the type annotation so you can copy it into your code:\n\n(.*)$/)[1]
-      }];
+      matches = problem.details.match(/I inferred the type annotation so you can copy it into your code:\n\n(.*)$/);
+      if (matches && matches.length > 1) {
+        return [{
+          type: 'Add type annotation',
+          text: matches[1]
+        }];
+      }
+      return null;
     case 'TYPE MISMATCH':
+      // TODO: The type annotation is saying:\n\n    (.*)\n\nBut I am inferring that the definition has this type:\n\n    (.*)$
       matches = problem.details.match(/But I am inferring that the definition has this type:\n\n    (.*)\n\nHint: A type annotation is too generic\. You can probably just switch to the type\nI inferred\. These issues can be subtle though, so read more about it\.\n<https:\/\/github\.com\/elm-lang\/elm-compiler\/blob\/0\.16\.0\/hints\/type-annotations\.md>$/);
-      if (matches) {
+      if (matches && matches.length > 1) {
         return [{
           type: 'Replace with',
           text: matches[1]
@@ -282,7 +287,7 @@ function getFixesForProblem(problem, rangeText) {
       return null;
     case 'ALIAS PROBLEM':
       matches = problem.details.match(/Try this instead:\n\n((.|\n)*)\n\nThis is kind of a subtle distinction\. I suggested the naive fix, but you can\noften do something a bit nicer\. So I would recommend reading more at:\n<https:\/\/github\.com\/elm-lang\/elm-compiler\/blob\/0\.16\.0\/hints\/recursive-alias\.md>$/);
-      if (matches) {
+      if (matches && matches.length > 1) {
         return [{
           type: 'Replace with',
           text: matches[1].split('\n').map((line) => {

--- a/lib/linter-elm-make.js
+++ b/lib/linter-elm-make.js
@@ -220,7 +220,7 @@ function getFixesForProblem(problem) {
         text: problem.details.match(/I inferred the type annotation so you can copy it into your code:\n\n(.*)$/)[1]
       }];
     default:
-      console.error('Unhandled problem tag: ' + problem.tag);
+      console.error('Unhandled tag: ' + problem.tag);
       return null;
   }
 }

--- a/lib/quick-fix-view.js
+++ b/lib/quick-fix-view.js
@@ -20,6 +20,7 @@ class QuickFixView extends SelectListView {
 
   destroy () {
     this.emitter.dispose();
+    this.panel.destroy();
   }
 
   onDidConfirm(fn) {
@@ -36,7 +37,8 @@ class QuickFixView extends SelectListView {
   }
 
   viewForItem(fix) {
-    return '<li><span class="fix-type">' + fix.type + ':</span>' + htmlEncode(fix.text.replace('\n', '\\n')) + '</li>';
+    const text = htmlEncode(fix.text.replace('\n', '\\n'));
+    return `<li><span class="fix-type">${fix.type}:</span>${text}</li>`;
   }
 
   confirmed(fix) {

--- a/lib/quick-fix-view.js
+++ b/lib/quick-fix-view.js
@@ -1,0 +1,58 @@
+"use babel";
+
+const SelectListView = require('atom-space-pen-views').SelectListView;
+const Emitter = require('atom').Emitter;
+
+module.exports =
+class QuickFixView extends SelectListView {
+  constructor() {
+    super();
+  }
+
+  initialize() {
+    super.initialize();
+    this.addClass('overlay linter-elm-make');
+    if (!this.panel) {
+      this.panel = atom.workspace.addModalPanel({item: this, visible: false});
+    }
+    this.emitter = new Emitter();
+  }
+
+  destroy () {
+    this.emitter.dispose();
+  }
+
+  onDidConfirm(fn) {
+    this.emitter.on('did-confirm', fn);
+  }
+
+  show(textEditor, range, fixes) {
+    this.textEditor = textEditor;
+    this.problemRange = range;
+    this.setItems(fixes);
+    this.panel.show();
+    this.storeFocusedElement();
+    this.focusFilterEditor();
+  }
+
+  viewForItem(fix) {
+    return '<li><span class="fix-type">' + fix.type + ':</span>' + htmlEncode(fix.text.replace('\n', '\\n')) + '</li>';
+  }
+
+  confirmed(fix) {
+    this.emitter.emit('did-confirm', {
+      textEditor: this.textEditor,
+      range: this.problemRange,
+      fix: fix
+    });
+    this.cancel();
+  }
+
+  cancelled(item) {
+    this.panel.hide();
+  }
+}
+
+function htmlEncode(html) {
+  return document.createElement('a').appendChild(document.createTextNode(html)).parentNode.innerHTML;
+}

--- a/lib/quick-fix-view.js
+++ b/lib/quick-fix-view.js
@@ -51,7 +51,7 @@ class QuickFixView extends SelectListView {
   cancelled(item) {
     this.panel.hide();
   }
-}
+};
 
 function htmlEncode(html) {
   return document.createElement('a').appendChild(document.createTextNode(html)).parentNode.innerHTML;

--- a/package.json
+++ b/package.json
@@ -10,7 +10,9 @@
   },
   "dependencies": {
     "fs": "0.0.2",
-    "path": "^0.12.7"
+    "path": "^0.12.7",
+    "space-pen": "^4.2.2",
+    "atom-space-pen-views": "^0.20.0"
   },
   "providedServices": {
     "linter": {

--- a/styles/linter-elm-make.less
+++ b/styles/linter-elm-make.less
@@ -1,0 +1,8 @@
+@import "ui-variables";
+
+.linter-elm-make {
+  .fix-type {
+    padding-right: @component-padding;
+    color: @text-color-info;
+  }
+}


### PR DESCRIPTION
Hi,

This is a quick-and-dirty implementation of "Quick Fix".

Move your cursor to a problematic text range and choose `Linter Elm Make: Quick Fix` from the command palette to show the possible fixes.  Select a fix from the list to apply it to your code.

![screen shot 2016-03-17 at 9 24 01 pm](https://cloud.githubusercontent.com/assets/2138906/13847155/ad4da6c2-ec86-11e5-963e-32202d3fd9de.png)

There's also `Linter Elm Make: Quick Fix All` which will fix all the issues in the active text editor.  If there is more than one fix for an issue, it will choose the first from the list.

You can also add something like this in your keymap.cson:

```
'atom-text-editor:not([mini])[data-grammar^="source elm"]':
  'f6': 'linter-elm-make:quick-fix'
  'shift-f6': 'linter-elm-make:quick-fix-all'
```

I used https://github.com/elm-lang/error-message-catalog to find out the possible errors/warnings.  There's probably more :)
