### PR TITLE
Fix #58, Make `Clear Project Build Artifacts` work in Windows

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ Show `elm-make` warnings.  Enabled by default.
 
 If this option is not blank, a file watcher will watch the project directory for source file changes and synchronize those with the work directory.
 
-IMPORTANT WARNING: If the work directory is inside the project directory and you want to change the value of `Work Directory`, delete the work directory first!  Else, the linter will consider the work directory as part of your project.
+IMPORTANT WARNING: If the current work directory is inside the project directory and you want to change the value of `Work Directory` in the settings, delete the current work directory first!  Else, the linter will consider that directory as part of your project!
 
 If this option makes no sense and/or is confusing, just leave it blank. :)
 

--- a/lib/linter-elm-make.js
+++ b/lib/linter-elm-make.js
@@ -631,11 +631,13 @@ module.exports = {
           const isMainPathInsideSourceDirectory = (sourceDirectories, filePath) => {
             // TODO Check if `sourceDirectories` is an array of strings.
             if (sourceDirectories) {
-              sourceDirectories.forEach((sourceDirectory) => {
+              for (var i in sourceDirectories) {
+                const sourceDirectory = sourceDirectories[i];
+                console.log(filePath, sourceDirectory, path.resolve(projectDirectory, sourceDirectory) + path.sep, filePath.startsWith(path.resolve(projectDirectory, sourceDirectory) + path.sep));
                 if (filePath.startsWith(path.resolve(projectDirectory, sourceDirectory) + path.sep)) {
                   return true;
                 }
-              });
+              }
             }
             return false;
           };

--- a/lib/linter-elm-make.js
+++ b/lib/linter-elm-make.js
@@ -324,7 +324,7 @@ module.exports = {
   //     const projectDirectory = lookupElmPackage(path.dirname(editorFilePath));
   //     let buildArtifactsDirectoryCleared;
   //     try {
-  //       fs.remove(buildArtifactsDirectory);
+  //       fs.removeSync(buildArtifactsDirectory);
   //       buildArtifactsDirectoryCleared = true;
   //     } catch(e) {
   //     }
@@ -339,7 +339,7 @@ module.exports = {
   //           const workDirectoryBuildArtifactsDirectory = buildArtifactsDirectory.replace(projectDirectory, workDirectory);
   //           let workDirectoryBuildArtifactsDirectoryCleared;
   //           try {
-  //             fs.remove(workDirectoryBuildArtifactsDirectory);
+  //             fs.removeSync(workDirectoryBuildArtifactsDirectory);
   //             workDirectoryBuildArtifactsDirectoryCleared = true;
   //           } catch(e) {
   //           }
@@ -374,7 +374,7 @@ module.exports = {
               // If work directory does not exist, create it and copy source files from project directory.
               if (!fs.existsSync(workDirectory)) {
                 if (atom.inDevMode()) {
-                  console.log('linter-elm-make: created work directory - ' + workDirectory + ' -> ' + projectDirectory);
+                  console.log('linter-elm-make: created work directory - ' + projectDirectory + ' -> ' + workDirectory);
                 }
                 self.copyProjectToWorkDirectory(projectDirectory, workDirectory);
               }
@@ -424,28 +424,53 @@ module.exports = {
     return linter;
   },
   copyProjectToWorkDirectory(projectDirectory, workDirectory) {
-    // Recursively copy `.elm` files, `elm-package.json`, and `elm-stuff` from project directory to work directory.
+    // Recursively copy source directories, `elm-package.json`, and `elm-stuff` from project directory to work directory.
     // Initial linting might take time depending on the project directory size.
-    const filePathFilter = (filePath) => {
-      return fs.lstatSync(filePath).isFile() &&
-        (path.dirname(filePath).replace(projectDirectory, '').startsWith(path.sep + 'elm-stuff' + path.sep) ||
-         path.basename(filePath) === 'elm-package.json' ||
-         path.extname(filePath) === '.elm');
+    const copyOptions = {
+      preserveTimestamps: true
     };
-    // If work directory is inside project directory...
-    if ((workDirectory + path.sep).startsWith(projectDirectory)) {
-      const files = readDir.readSync(projectDirectory, null, readDir.ABSOLUTE_PATHS);
-      files.forEach((file) => {
-        fs.copySync(file, file.replace(projectDirectory, workDirectory), {
-          preserveTimestamps: true,
-          filter: filePathFilter
+    // Copy `elm-package.json` to work directory.
+    const elmPackageJsonFilePath = path.join(projectDirectory, 'elm-package.json');
+    fs.copySync(elmPackageJsonFilePath, path.join(workDirectory, 'elm-package.json'), copyOptions);
+    // Copy `elm-stuff` to work directory.
+    // Assumes that work directory is not inside `elm-stuff`.
+    const elmStuffFilePath = path.join(projectDirectory, 'elm-stuff');
+    if (fs.existsSync(elmStuffFilePath)) {
+      fs.copySync(elmStuffFilePath, path.join(workDirectory, 'elm-stuff'), copyOptions);
+    }
+    // Copy source directories to work directory.
+    // Be careful with source directories outside of the project directory (e.g. "../../src").
+    let json = fs.readJsonSync(path.join(projectDirectory, 'elm-package.json'), {throws: false});
+    if (json) {
+      // TODO Check if `sourceDirectories` is an array of strings.
+      const sourceDirectories = json['source-directories'];
+      if (sourceDirectories) {
+        const copyOptionsWithFilter = JSON.parse(JSON.stringify(copyOptions));
+        copyOptionsWithFilter.filter = (filePath) => {
+          return !filePath.startsWith(workDirectory + path.sep);
+        };
+        sourceDirectories.forEach((sourceDirectory) => {
+          const projectSourceDirectory = path.resolve(projectDirectory, sourceDirectory);
+          const workSourceDirectory = path.resolve(workDirectory, sourceDirectory);
+          if (fs.existsSync(projectSourceDirectory)) {
+            // If work directory is inside project directory...
+            if ((workDirectory + path.sep).startsWith(projectDirectory)) {
+              const projectFilePaths = readDir.readSync(projectSourceDirectory, null, readDir.ABSOLUTE_PATHS);
+              projectFilePaths.forEach((projectFilePath) => {
+                const workFilePath = projectFilePath.replace(projectDirectory, workDirectory);
+                fs.copySync(projectFilePath, workFilePath, copyOptionsWithFilter);
+              });
+            } else {
+              fs.copySync(projectSourceDirectory, workSourceDirectory, copyOptions);
+            }
+            if (atom.inDevMode()) {
+              if (fs.existsSync(workSourceDirectory)) {
+                console.log('linter-elm-make: copied source directory to work directory - ' + projectSourceDirectory + ' -> ' + workSourceDirectory);
+              }
+            }
+          }
         });
-      });
-    } else {
-      fs.copySync(projectDirectory, workDirectory, {
-        preserveTimestamps: true,
-        filter: filePathFilter
-      });
+      }
     }
   },
   watchProjectDirectory(projectDirectory, workDirectory) {
@@ -471,15 +496,25 @@ module.exports = {
          filePath.startsWith(path.join(projectDirectory, 'elm-stuff', 'packages')) ||
          path.extname(filePath) === '.elm')) {
         if (atom.inDevMode()) {
-          console.log('linter-elm-make: add detected - ', filePath);
+          console.log('linter-elm-make: add detected - ' + filePath);
         }
         fs.copySync(filePath, path.join(workDirectory, filename));
       }
     });
+    // watcher.on('addDir', (filename) => {
+    //   const filePath = path.join(projectDirectory, filename);
+    //   if (!filePath.startsWith(workDirectory + path.sep) &&
+    //     filePath.startsWith(path.join(projectDirectory, 'elm-stuff', 'packages'))) {
+    //     if (atom.inDevMode()) {
+    //       console.log('linter-elm-make: addDir detected - ' + filePath);
+    //     }
+    //     fs.mkdirsSync(path.join(workDirectory, filename));
+    //   }
+    // });
     watcher.on('unlink', (filename) => {
       const filePath = path.join(projectDirectory, filename);
       if (atom.inDevMode()) {
-        console.log('linter-elm-make: unlink detected - ', filePath);
+        console.log('linter-elm-make: unlink detected - ' + filePath);
       }
       if (!filePath.startsWith(workDirectory + path.sep)) {
         fs.removeSync(path.join(workDirectory, filename));
@@ -488,7 +523,7 @@ module.exports = {
     watcher.on('unlinkDir', (dirname) => {
       const dirPath = path.join(projectDirectory, dirname);
       if (atom.inDevMode()) {
-        console.log('linter-elm-make: unlinkDir detected - ', dirPath);
+        console.log('linter-elm-make: unlinkDir detected - ' + dirPath);
       }
       if (!dirPath.startsWith(workDirectory + path.sep)) {
         fs.removeSync(path.join(workDirectory, dirname));
@@ -500,8 +535,13 @@ module.exports = {
         (filePath === path.join(projectDirectory, 'elm-package.json') ||
          filePath === path.join(projectDirectory, 'elm-stuff', 'exact-dependencies.json'))) {
         if (atom.inDevMode()) {
-          console.log('linter-elm-make: change detected - ', filename);
+          console.log('linter-elm-make: change detected - ' + filename);
         }
+
+        // TODO Only do these if the value of "source-directories" was changed:
+        this.deleteSourceDirectoriesInWorkDirectory(projectDirectory, workDirectory);
+        this.copyProjectToWorkDirectory(projectDirectory, workDirectory);
+
         const workFilePath = path.join(workDirectory, filePath.replace(projectDirectory, ''));
         fs.writeFileSync(workFilePath, fs.readFileSync(filePath).toString());
         if (filePath === path.join(projectDirectory, 'elm-package.json')) {
@@ -511,6 +551,22 @@ module.exports = {
     });
     // TODO Handle when projectDirectory gets renamed or deleted.
     // TODO When to close watcher, delete temporary directory, and delete self.workDirectories[projectDirectory]?
+  },
+  deleteSourceDirectoriesInWorkDirectory(projectDirectory, workDirectory) {
+    let json = fs.readJsonSync(path.join(projectDirectory, 'elm-package.json'), {throws: false});
+    if (json) {
+      const sourceDirectories = json['source-directories'];
+      // TODO Check if `sourceDirectories` is an array of strings.
+      if (sourceDirectories) {
+        sourceDirectories.forEach((sourceDirectory) => {
+          const workDirectorySourceDirectory = path.resolve(workDirectory, sourceDirectory);
+          fs.removeSync(workDirectorySourceDirectory);
+          if (atom.inDevMode()) {
+            console.log('linter-elm-make: deleted source directory in work directory - ' + workDirectorySourceDirectory);
+          }
+        });
+      }
+    }
   },
   provideGetWorkDirectory() {
     const self = this;
@@ -564,16 +620,33 @@ module.exports = {
       const BreakException = {};
       try {
         return mainPaths.map((mainPath) => {
-          const mainFilePath = path.join(projectDirectory, mainPath);
-          if (fs.existsSync(mainFilePath)) {
-            return mainFilePath;
-          } else {
+          const mainFilePath = path.resolve(projectDirectory, mainPath);
+          if (!fs.existsSync(mainFilePath)) {
             atom.notifications.addError('The main path `' + mainPath + '` does not exist', {
               detail: errorDetail,
               dismissable: true
             });
             throw BreakException;
           }
+          const isMainPathInsideSourceDirectory = (sourceDirectories, filePath) => {
+            // TODO Check if `sourceDirectories` is an array of strings.
+            if (sourceDirectories) {
+              sourceDirectories.forEach((sourceDirectory) => {
+                if (filePath.startsWith(path.resolve(projectDirectory, sourceDirectory) + path.sep)) {
+                  return true;
+                }
+              });
+            }
+            return false;
+          };
+          if (!isMainPathInsideSourceDirectory(json['source-directories'], mainFilePath)) {
+            atom.notifications.addError('The main path `' + mainPath + '` is not inside a source directory', {
+              detail: errorDetail,
+              dismissable: true
+            });
+            throw BreakException;
+          }
+          return mainFilePath;
         });
       } catch(e) {
         if (e !== BreakException) {

--- a/lib/linter-elm-make.js
+++ b/lib/linter-elm-make.js
@@ -633,7 +633,6 @@ module.exports = {
             if (sourceDirectories) {
               for (var i in sourceDirectories) {
                 const sourceDirectory = sourceDirectories[i];
-                console.log(filePath, sourceDirectory, path.resolve(projectDirectory, sourceDirectory) + path.sep, filePath.startsWith(path.resolve(projectDirectory, sourceDirectory) + path.sep));
                 if (filePath.startsWith(path.resolve(projectDirectory, sourceDirectory) + path.sep)) {
                   return true;
                 }

--- a/lib/linter-elm-make.js
+++ b/lib/linter-elm-make.js
@@ -796,13 +796,13 @@ function getProjectBuildArtifactsDirectory(filePath) {
       env: process.env
     })
     .then(data => {
-      var elmPlatformVersion = data.split('\n')[0].match(/\(Elm Platform (.*)\)$/)[1];
+      var elmPlatformVersion = data.split('\n')[0].match(/\(Elm Platform (.*)\)/)[1];
       let json = fs.readJsonSync(path.join(projectDirectory, 'elm-package.json'), {throws: false});
       if (json) {
         if (json.repository && json.version) {
           const matches = json.repository.match(/^(.+)\/(.+)\/(.+)\.git$/);
-          const user = matches[2];
-          const project = matches[3];
+          const user = (matches && matches.length > 2 && matches[2]) || null;
+          const project = (matches && matches.length > 3 && matches[3]) || null;
           if (user && project) {
             return path.join(projectDirectory, 'elm-stuff', 'build-artifacts', elmPlatformVersion, user, project, json.version);
           } else {


### PR DESCRIPTION
Fix #58, Make `Clear Project Build Artifacts` work in Windows
