### PR TITLE
Update README with clearer instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ Lint your Elm files in Atom with [linter](https://github.com/atom-community/lint
   apm install linter-elm-make
   ```
 1. Run `which elm-make` (Unix/Linux) or `where.exe elm-make` (Windows) from the command line and set the result as your executable path in this installed package's configuration.
-  - Press Cmd-, or Ctrl-,
+  - Press <kbd>Cmd</kbd><kbd>,</kbd> or <kbd>Ctrl</kbd><kbd>,</kbd>
   - Click the "Packages" menu item in the left pane.
   - Click on the "linter-elm-make" package in the list that appears.
   - Scroll down to the "Settings" section and enter the path to your `elm-make` in the text field labeled "The elm-make executable path." (Your path should look something like `/usr/local/bin/elm-make`.)

--- a/README.md
+++ b/README.md
@@ -14,6 +14,10 @@ Lint your Elm files in Atom with [linter](https://github.com/atom-community/lint
   apm install linter-elm-make
   ```
 1. Run `which elm-make` (Unix/Linux) or `where.exe elm-make` (Windows) from the command line and set the result as your executable path in this installed package's configuration.
+  - Press Cmd-, or Ctrl-,
+  - Click the "Packages" menu item in the left pane.
+  - Click on the "linter-elm-make" package in the list that appears.
+  - Scroll down to the "Settings" section and enter the path to your `elm-make` in the text field labeled "The elm-make executable path." (Your path should look something like `/usr/local/bin/elm-make`.)
 
 ## Configuration
 


### PR DESCRIPTION
@halohalospecial I think it's good that these instructions are now clearer for those who are new to Atom, but do you know of a way we can make it so users don't even have to do this?
