### PR TITLE
Undo 0.13.3, Save `mainPaths` to `linter-elm-make.json`, ...

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## 0.14.0
+* Undo 0.13.3!  Run a separate `elm-make` process again for each main path because there is an issue with files having the same module name.
+* Save `mainPaths` to `linter-elm-make.json` instead of `elm-package.json`.
+* Fix wrong links in README.md.
+
 ## 0.13.3
 * Run only 1 `elm-make` process for multiple main paths.
 

--- a/README.md
+++ b/README.md
@@ -1,13 +1,13 @@
 # linter-elm-make
 
-Lint your Elm files in Atom with [linter](https://github.com/atom-community/linter) and `elm-make`.
+Lint your Elm files in Atom with [linter](https://atom.io/packages/linter) and `elm-make`.
 
 ![lint-on-fly](https://github.com/mybuddymichael/linter-elm-make/blob/master/images/lint-on-fly.gif?raw=true)
 
 ## Installation
 
 1. Install [`elm`](http://elm-lang.org/install).
-1. Install [`linter`](https://github.com/atom-community/linter), [`language-elm`](https://github.com/atom-community/language-elm), and [`linter-elm-make`](https://github.com/atom-community/linter-elm-make) from the Settings view (`Edit` > `Preferences` > `Install`) or by running these from the command line:
+1. Install [`linter`](https://atom.io/packages/linter), [`language-elm`](https://atom.io/packages/language-elm), and [`linter-elm-make`](https://atom.io/packages/linter-elm-make) from the Settings view (`Edit` > `Preferences` > `Install`) or by running these from the command line:
   ```
   apm install linter
   apm install language-elm
@@ -18,7 +18,7 @@ Lint your Elm files in Atom with [linter](https://github.com/atom-community/lint
 ## Configuration
 
 #### `Lint On The Fly`
-By default, linting is only done after saving the file.  If you want to lint while typing, turn on the `Lint On The Fly` option in the package settings.  Also make sure that the `Lint As You Type` option is enabled in the [linter](https://github.com/atom-community/linter) package settings.
+By default, linting is only done after saving the file.  If you want to lint while typing, turn on the `Lint On The Fly` option in the package settings.  Also make sure that the `Lint As You Type` option is enabled in the [linter](https://atom.io/packages/linter) package settings.
 
 #### `Always Compile Main`
 If enabled, the main file(s) will always be compiled instead of the active file.  The main files can be set using `Linter Elm Make: Set Main Paths`.  If not set, the linter will look for `Main.elm` files in the source directories.  Take note that if this is enabled, modules unreachable from the main modules will not be linted.  Disabled by default.
@@ -63,17 +63,15 @@ You may also add something like this in your `keymap.cson`:
 ```
 
 #### `Linter Elm Make: Set Main Paths`
-Sets the main paths of the project and saves them to `elm-package.json`.
+Sets the main paths of the project and saves them to `linter-elm-make.json`.
 
 Example:
 ```
-"linter-elm-make": {
+{
   "mainPaths": ["Todo.elm", "Test.elm"]
 }
 ```
 The main paths are only relevant if `Always Compile Main` is enabled.  See [above](https://github.com/mybuddymichael/linter-elm-make#always-compile-main).
-
-WARNING: Running `elm-package install` removes `mainPaths` from `elm-package.json` so you need to invoke `Linter Elm Make: Set Main Paths` again after.
 
 #### `Linter Elm Make: Clear Project Build Artifacts`
 Deletes the `.elmi` and `.elmo` files in your project's build artifacts directory (e.g. elm-stuff/build-artifacts/0.17.0/user/project/1.0.0).  This is useful after toggling `Lint On The Fly` and/or `Always Compile Main` to prevent confusing lint results.  If using a work directory or temporary directory, the artifact files of that directory will also be deleted.
@@ -83,6 +81,16 @@ Deletes the `.elmi` and `.elmo` files in your project's build artifacts director
 #### `Linter Elm Make: Toggle Always Compile Main`
 
 #### `Linter Elm Make: Toggle Report Warnings`
+
+## Useful [`linter`](https://atom.io/packages/linter) Commands
+
+#### `Linter: Lint`
+
+#### `Linter: Next Error`
+
+#### `Linter: Previous Error`
+
+#### `Linter: Toggle`
 
 ## Prior Art
 

--- a/lib/linter-elm-make.js
+++ b/lib/linter-elm-make.js
@@ -63,7 +63,6 @@ module.exports = {
     }
     // If `elm-format` is installed and there are errors/warnings, the red/yellow squigglies will disappear after saving.
     // The workaround here is to monkey patch the success() function of `elm-format` to refresh the lint results.
-    // Please forgive me.
     const elmFormat = atom.packages.getLoadedPackage('elm-format');
     if (elmFormat) {
       const originalSuccessFunction = elmFormat.mainModule.success;
@@ -96,19 +95,22 @@ module.exports = {
       self.clearElmEditorProblemsAndFixes(editor);
     });
     this.setMainPathsView.onDidConfirm(({projectDirectory, mainPaths}) => {
-      const jsonFilePath = path.join(projectDirectory, 'elm-package.json');
-      let json = fs.readJsonSync(jsonFilePath, {throws: false});
-      if (json) {
-        json['linter-elm-make'] = {mainPaths: mainPaths};
-        fs.writeJsonSync(jsonFilePath, json);
-        atom.notifications.addSuccess('Set main paths to `[' + mainPaths.map((mainPath) => '"' + mainPath + '"').join(', ') + ']` in `elm-package.json`', {});
-        if (atom.config.get('linter-elm-make.lintOnTheFly')) {
-          forceLintActiveElmEditor();
+      const jsonFilePath = path.join(projectDirectory, 'linter-elm-make.json');
+      let json;
+      if (fs.existsSync(jsonFilePath)) {
+        json = fs.readJsonSync(jsonFilePath, {throws: false});
+        if (!json) {
+          atom.notifications.addError('Error reading `linter-elm-make.json`', {dismissable: true});
+          return;
         }
+        json.mainPaths = mainPaths;
       } else {
-        atom.notifications.addError('Error reading `elm-package.json`', {
-          dismissable: true
-        });
+        json = {mainPaths: mainPaths};
+      }
+      fs.writeJsonSync(jsonFilePath, json);
+      atom.notifications.addSuccess('Set main paths to `[' + mainPaths.map((mainPath) => '"' + mainPath + '"').join(', ') + ']` in `linter-elm-make.json`', {});
+      if (atom.config.get('linter-elm-make.lintOnTheFly')) {
+        forceLintActiveElmEditor();
       }
     });
     let subscribeToElmEditorEvents = (editor) => {
@@ -267,12 +269,13 @@ module.exports = {
       if (!projectDirectory) {
         return;
       }
-      let json = fs.readJsonSync(path.join(projectDirectory, 'elm-package.json'), {throws: false});
-      if (json) {
-        const linterElmMake = json['linter-elm-make'];
-        const mainPaths = (linterElmMake && linterElmMake.mainPaths) || [];
-        this.setMainPathsView.show(editorFilePath.replace(projectDirectory + path.sep, ''), projectDirectory, mainPaths);
+      const jsonFilePath = path.join(projectDirectory, 'linter-elm-make.json');
+      let json;
+      if (fs.existsSync(jsonFilePath)) {
+        json = fs.readJsonSync(jsonFilePath, {throws: false});
       }
+      const mainPaths = (json && json.mainPaths) || [];
+      this.setMainPathsView.show(editorFilePath.replace(projectDirectory + path.sep, ''), projectDirectory, mainPaths);
     }
   },
   // Deletes the .elmi and .elmo files in your project's build artifacts directory (e.g. elm-stuff/build-artifacts/0.17.0/user/project/1.0.0).
@@ -299,7 +302,7 @@ module.exports = {
         const projectDirectory = lookupElmPackage(path.dirname(editorFilePath));
         const buildArtifactsDirectoryCleared = deleteBuildArtifacts(buildArtifactsDirectory);
         if (buildArtifactsDirectoryCleared && atom.inDevMode()) {
-          console.log('linter-elm-make: cleared project directory build artifacts - ' + buildArtifactsDirectory);
+          console.log('[linter-elm-make] Cleared project directory build artifacts - ' + buildArtifactsDirectory);
         }
         if (atom.config.get('linter-elm-make.lintOnTheFly')) {
           // If linting on the fly, also delete the build artifacts in the work directory.
@@ -309,7 +312,7 @@ module.exports = {
               const workDirectoryBuildArtifactsDirectory = buildArtifactsDirectory.replace(projectDirectory, workDirectory);
               const workDirectoryBuildArtifactsDirectoryCleared = deleteBuildArtifacts(workDirectoryBuildArtifactsDirectory);
               if (workDirectoryBuildArtifactsDirectoryCleared && atom.inDevMode()) {
-                console.log('linter-elm-make: cleared work directory build artifacts - ' + workDirectoryBuildArtifactsDirectory);
+                console.log('[linter-elm-make] Cleared work directory build artifacts - ' + workDirectoryBuildArtifactsDirectory);
               }
             }
           }
@@ -332,7 +335,7 @@ module.exports = {
   //     } catch(e) {
   //     }
   //     if (buildArtifactsDirectoryCleared && atom.inDevMode()) {
-  //       console.log('linter-elm-make: cleared project directory build artifacts - ' + buildArtifactsDirectory);
+  //       console.log('[linter-elm-make] Cleared project directory build artifacts - ' + buildArtifactsDirectory);
   //     }
   //     if (atom.config.get('linter-elm-make.lintOnTheFly')) {
   //       // If linting on the fly, also delete the build artifacts in the work directory.
@@ -347,7 +350,7 @@ module.exports = {
   //           } catch(e) {
   //           }
   //           if (workDirectoryBuildArtifactsDirectoryCleared && atom.inDevMode()) {
-  //             console.log('linter-elm-make: cleared work directory build artifacts - ' + workDirectoryBuildArtifactsDirectory);
+  //             console.log('[linter-elm-make] Cleared work directory build artifacts - ' + workDirectoryBuildArtifactsDirectory);
   //           }
   //         }
   //       }
@@ -377,7 +380,7 @@ module.exports = {
               // If work directory does not exist, create it and copy source files from project directory.
               if (!fs.existsSync(workDirectory)) {
                 if (atom.inDevMode()) {
-                  console.log('linter-elm-make: created work directory - ' + projectDirectory + ' -> ' + workDirectory);
+                  console.log('[linter-elm-make] Created work directory - ' + projectDirectory + ' -> ' + workDirectory);
                 }
                 self.copyProjectToWorkDirectory(projectDirectory, workDirectory);
               }
@@ -390,7 +393,7 @@ module.exports = {
               // Create a temporary directory for the project.
               const workDirectory = tmp.dirSync({prefix: 'linter-elm-make'}).name;
               if (atom.inDevMode()) {
-                console.log('linter-elm-make: created temporary work directory - ' + workDirectory + ' -> ' + projectDirectory);
+                console.log('[linter-elm-make] Created temporary work directory - ' + workDirectory + ' -> ' + projectDirectory);
               }
               self.workDirectories[projectDirectory] = workDirectory;
               self.copyProjectToWorkDirectory(projectDirectory, workDirectory);
@@ -404,7 +407,7 @@ module.exports = {
               return self.compileMainFiles(editorFilePath, projectDirectory, workDirectory, editor, (mainFilePath) => mainFilePath);
             } else {
               // Compile active file.
-              return self.executeElmMake(editorFilePath, [editorFilePath], workDirectory, editor, projectDirectory);
+              return self.executeElmMake(editorFilePath, editorFilePath, workDirectory, editor, projectDirectory);
             }
           }
         }
@@ -429,7 +432,7 @@ module.exports = {
   copyProjectToWorkDirectory(projectDirectory, workDirectory, options) {
     atom.notifications.addInfo('Copying project files to work directory `' + workDirectory + '`...', {});
     if (atom.inDevMode()) {
-      console.log('linter-elm-make: copying project directory to work directory - ' + projectDirectory + ' -> ' + workDirectory);
+      console.log('[linter-elm-make] Copying project directory to work directory - ' + projectDirectory + ' -> ' + workDirectory);
     }
     // Use `setTimeout` to force the notification above to appear immediately.
     setTimeout(() => {
@@ -479,7 +482,7 @@ module.exports = {
             }
             if (atom.inDevMode()) {
               if (fs.existsSync(workSourceDirectory)) {
-                console.log('linter-elm-make: copied source directory to work directory - ' + projectSourceDirectory + ' -> ' + workSourceDirectory);
+                console.log('[linter-elm-make] Copied source directory to work directory - ' + projectSourceDirectory + ' -> ' + workSourceDirectory);
               }
             }
           }
@@ -487,7 +490,7 @@ module.exports = {
       }
       atom.notifications.addSuccess('Copied project files to work directory `' + workDirectory + '`', {});
       if (atom.inDevMode()) {
-        console.log('linter-elm-make: copied project directory to work directory - ' + projectDirectory + ' -> ' + workDirectory);
+        console.log('[linter-elm-make] Copied project directory to work directory - ' + projectDirectory + ' -> ' + workDirectory);
       }
       setTimeout(() => {
         forceLintActiveElmEditor();
@@ -517,7 +520,7 @@ module.exports = {
          filePath.startsWith(path.join(projectDirectory, 'elm-stuff', 'packages')) ||
          path.extname(filePath) === '.elm')) {
         if (atom.inDevMode()) {
-          console.log('linter-elm-make: add detected - ' + filePath);
+          console.log('[linter-elm-make] `add` detected - ' + filePath);
         }
         fs.copySync(filePath, path.join(workDirectory, filename));
       }
@@ -527,7 +530,7 @@ module.exports = {
     //   if (!filePath.startsWith(workDirectory + path.sep) &&
     //     filePath.startsWith(path.join(projectDirectory, 'elm-stuff', 'packages'))) {
     //     if (atom.inDevMode()) {
-    //       console.log('linter-elm-make: addDir detected - ' + filePath);
+    //       console.log('[linter-elm-make] `addDir` detected - ' + filePath);
     //     }
     //     fs.mkdirsSync(path.join(workDirectory, filename));
     //   }
@@ -535,7 +538,7 @@ module.exports = {
     watcher.on('unlink', (filename) => {
       const filePath = path.join(projectDirectory, filename);
       if (atom.inDevMode()) {
-        console.log('linter-elm-make: unlink detected - ' + filePath);
+        console.log('[linter-elm-make] `unlink` detected - ' + filePath);
       }
       if (!filePath.startsWith(workDirectory + path.sep)) {
         fs.removeSync(path.join(workDirectory, filename));
@@ -544,7 +547,7 @@ module.exports = {
     watcher.on('unlinkDir', (dirname) => {
       const dirPath = path.join(projectDirectory, dirname);
       if (atom.inDevMode()) {
-        console.log('linter-elm-make: unlinkDir detected - ' + dirPath);
+        console.log('[linter-elm-make] `unlinkDir` detected - ' + dirPath);
       }
       if (!dirPath.startsWith(workDirectory + path.sep)) {
         fs.removeSync(path.join(workDirectory, dirname));
@@ -556,7 +559,7 @@ module.exports = {
         (filePath === path.join(projectDirectory, 'elm-package.json') ||
          filePath === path.join(projectDirectory, 'elm-stuff', 'exact-dependencies.json'))) {
         if (atom.inDevMode()) {
-          console.log('linter-elm-make: change detected - ' + filename);
+          console.log('[linter-elm-make] `change` detected - ' + filename);
         }
 
         // TODO Only do this if the value of "source-directories" was changed:
@@ -582,7 +585,7 @@ module.exports = {
           const workDirectorySourceDirectory = path.resolve(workDirectory, sourceDirectory);
           fs.removeSync(workDirectorySourceDirectory);
           if (atom.inDevMode()) {
-            console.log('linter-elm-make: deleted source directory in work directory - ' + workDirectorySourceDirectory);
+            console.log('[linter-elm-make] Deleted source directory in work directory - ' + workDirectorySourceDirectory);
           }
         });
       }
@@ -609,31 +612,42 @@ module.exports = {
       return this.compileMainFiles(editorFilePath, projectDirectory, workDirectory, editor, (mainFilePath) => mainFilePath.replace(projectDirectory, workDirectory));
     } else {
       // Compile active file.
-      return this.executeElmMake(editorFilePath, [workFilePath], workDirectory, editor, projectDirectory);
+      return this.executeElmMake(editorFilePath, workFilePath, workDirectory, editor, projectDirectory);
     }
   },
   compileMainFiles(editorFilePath, projectDirectory, cwd, editor, mainFilePathTransformFunction) {
     const mainFilePaths = this.getMainFilePaths(projectDirectory);
     if (mainFilePaths) {
-      const transformedMainFilePaths = mainFilePaths.map((mainFilePath) => {
-        return mainFilePathTransformFunction(mainFilePath);
+      // Compile the main files, then combine the linting results.
+      const elmMakePromises = mainFilePaths.map((mainFilePath) => {
+        return this.executeElmMake(editorFilePath, mainFilePathTransformFunction(mainFilePath), cwd, editor, projectDirectory);
       });
-      return this.executeElmMake(editorFilePath, transformedMainFilePaths, cwd, editor, projectDirectory);
+      return Promise.all(elmMakePromises).then((results) => {
+        return flattenArray(results);
+      });
     } else {
       return [];
     }
   },
   getMainFilePaths(projectDirectory) {
-    let json = fs.readJsonSync(path.join(projectDirectory, 'elm-package.json'), {throws: false});
-    if (!json) {
+    const elmPackageJsonFilePath = path.join(projectDirectory, 'elm-package.json');
+    if (!fs.existsSync(elmPackageJsonFilePath)) {
       return null;
     }
-    const linterElmMake = json['linter-elm-make'];
-    const mainPaths = linterElmMake && linterElmMake.mainPaths;
+    const elmPackageJson = fs.readJsonSync(elmPackageJsonFilePath, {throws: false});
+    if (!elmPackageJson) {
+      return null;
+    }
+    const linterElmMakeJsonFilePath = path.join(projectDirectory, 'linter-elm-make.json');
+    let linterElmMakeJson;
+    if (fs.existsSync(linterElmMakeJsonFilePath)) {
+      linterElmMakeJson = fs.readJsonSync(linterElmMakeJsonFilePath, {throws: false});
+    }
+    const mainPaths = linterElmMakeJson && linterElmMakeJson.mainPaths;
     const errorDetail =
       'Note that "Always Compile Main" is ON.  You can do one of the following:\n' +
       ' - Turn off "Always Compile Main" in the package settings to compile the active file instead.\n' +
-      ' - Set the main paths of the project using `Linter Elm Make: Set Main Paths`. (Saves the main paths to `elm-package.json`.)\n' +
+      ' - Set the main paths of the project using `Linter Elm Make: Set Main Paths`. (Saves the main paths to `linter-elm-make.json`.)\n' +
       ' - Put a `Main.elm` file in at least one of the source directories.';
     // If `mainPaths` exists, use that.
     if (mainPaths && mainPaths.length > 0) {
@@ -660,7 +674,7 @@ module.exports = {
             }
             return false;
           };
-          if (!isMainPathInsideSourceDirectory(json['source-directories'], mainFilePath)) {
+          if (!isMainPathInsideSourceDirectory(elmPackageJson['source-directories'], mainFilePath)) {
             atom.notifications.addError('The main path `' + mainPath + '` is not inside a source directory', {
               detail: errorDetail,
               dismissable: true
@@ -677,7 +691,7 @@ module.exports = {
     } else {
       // Else, look for `Main.elm` files in the source directories.
       // TODO Check if `sourceDirectories` is an array of strings.
-      const sourceDirectories = json['source-directories'];
+      const sourceDirectories = elmPackageJson['source-directories'];
       if (sourceDirectories) {
         const mainFilePaths =
           sourceDirectories
@@ -703,17 +717,20 @@ module.exports = {
   consumeStatusBar(statusBar) {
     module.statusBar = statusBar;
   },
-  executeElmMake(editorFilePath, inputFilePaths, cwd, editor, projectDirectory) {
+  executeElmMake(editorFilePath, inputFilePath, cwd, editor, projectDirectory) {
     const executablePath = atom.config.get('linter-elm-make.elmMakeExecutablePath');
     const progressIndicator = module.statusBar.addLeftTile({
       item: createProgressIndicator(),
       priority: 1
     });
-    let args = inputFilePaths.concat(['--report=json', '--output=/dev/null', '--yes']);
+    let args = [inputFilePath, '--report=json', '--output=/dev/null', '--yes'];
     if (atom.config.get('linter-elm-make.reportWarnings')) {
       args.push('--warn');
     }
     let self = this;
+    if (atom.inDevMode()) {
+      console.log('[linter-elm-make] Executing ' + executablePath + ' ' + args.join(' '));
+    }
     return helpers.exec(executablePath, args, {
       stream: 'both', // stdout and stderr
       cwd: cwd,
@@ -900,19 +917,13 @@ function getProjectBuildArtifactsDirectory(filePath) {
           if (user && project) {
             return path.join(projectDirectory, 'elm-stuff', 'build-artifacts', elmPlatformVersion, user, project, json.version);
           } else {
-            atom.notifications.addError('Could not determine the value of "user" and/or "project"', {
-              dismissable: true
-            });
+            atom.notifications.addError('Could not determine the value of "user" and/or "project"', {dismissable: true});
           }
         } else {
-          atom.notifications.addError('Field "repository" and/or "version" not found in elm-package.json', {
-            dismissable: true
-          });
+          atom.notifications.addError('Field "repository" and/or "version" not found in elm-package.json', {dismissable: true});
         }
       } else {
-        atom.notifications.addError('Error parsing elm-package.json', {
-          dismissable: true
-        });
+        atom.notifications.addError('Error parsing elm-package.json', {dismissable: true});
       }
     })
     .catch(errorMessage => {


### PR DESCRIPTION
- Undo 0.13.3!  Run a separate `elm-make` process again for each main path because there is an issue with files having the same module name.
- Save `mainPaths` to `linter-elm-make.json` instead of `elm-package.json`.
- Fix wrong links in README.md.
