### PR TITLE
Fix filtering out child source directories in copy project

### DIFF
--- a/lib/linter-elm-make.js
+++ b/lib/linter-elm-make.js
@@ -436,15 +436,10 @@ export default {
             return !filePath.startsWith(workDirectory + path.sep);
           };
           // Filter out child source directories (i.e. if a source directory is inside another, do not copy files for that source directory anymore).
-          var parentSourceDirectories = [];
-          // Clone `sourceDirectories`.
-          var allSourceDirectories = sourceDirectories.slice();
-          allSourceDirectories.sort();
-          var i = 0;
-          while (i === 0 || (allSourceDirectories[i] + path.sep).startsWith(allSourceDirectories[i-1])) {
-            parentSourceDirectories.push(allSourceDirectories[i]);
-            i = i + 1;
-          }
+          parentSourceDirectories =
+            new Set(
+              sourceDirectories
+              .filter(x => !sourceDirectories.some(y => x != y && x.startsWith(y))))
           parentSourceDirectories.forEach((sourceDirectory) => {
             const projectSourceDirectory = path.resolve(projectDirectory, sourceDirectory);
             const workSourceDirectory = path.resolve(workDirectory, sourceDirectory);


### PR DESCRIPTION
If there are two or more project directories in elm-package.json, linter will copy only one of them. 
This fix this issue. 
