### PR TITLE
Refactoring filter out child source directories

### DIFF
--- a/lib/linter-elm-make.js
+++ b/lib/linter-elm-make.js
@@ -436,18 +436,12 @@ export default {
             return !filePath.startsWith(workDirectory + path.sep);
           };
           // Filter out child source directories (i.e. if a source directory is inside another, do not copy files for that source directory anymore).
-          var parentSourceDirectories = [];
-          var allSourceDirectories = sourceDirectories.map((sourceDirectory) => path.resolve(projectDirectory, sourceDirectory));
-          allSourceDirectories.sort();
-          // Exclude child source directories.
-          if (allSourceDirectories.length > 0) {
-            parentSourceDirectories.push(allSourceDirectories[0]);
-          }
-          _.rest(allSourceDirectories).forEach((sourceDirectory) => {
-            if (!(sourceDirectory + path.sep).startsWith(_.last(parentSourceDirectories))) {
-              parentSourceDirectories.push(sourceDirectory);
-            }
-          });
+          const allSourceDirectories = sourceDirectories.map(x => path.resolve(projectDirectory, x))
+          const parentSourceDirectories =
+            new Set(
+              allSourceDirectories
+                .filter(x => !allSourceDirectories.some(y => x != y && x.startsWith(y + path.sep))));
+
           parentSourceDirectories.forEach((projectSourceDirectory) => {
             const workSourceDirectory = projectSourceDirectory.replace(projectDirectory, workDirectory);
             if (fs.existsSync(projectSourceDirectory)) {


### PR DESCRIPTION
Hello again.
I fixed cases that you describe in previous PR. 
Also i realised that current version in the case of ["src", "srcA/child1", "srcB/child2"]  returns only ["src"]. Now everything should be ok. 
