### PR TITLE
filter haskell memory error messages

### DIFF
--- a/lib/linter-elm-make.js
+++ b/lib/linter-elm-make.js
@@ -715,6 +715,9 @@ export default {
     })
     .then(data => {
       let result;
+      // filter haskell memory error messages
+      // see https://ghc.haskell.org/trac/ghc/ticket/12495
+      data.stderr = data.stderr.split("\n").filter((line) => line !== "elm-make: unable to decommit memory: Invalid argument").join("\n");
       if (data.stderr === '') {
         result = self.parseStdout(data.stdout, editorFilePath, cwd, editor, projectDirectory);
       } else {


### PR DESCRIPTION
On my machine every haskell program outputs `unable to decommit memory: Invalid argument` because of a bug in the GHC's configure script:

``` sh
$ elm make
Success! Compiled 0 modules.                                        
elm-make: unable to decommit memory: Invalid argument
elm-make: unable to decommit memory: Invalid argument
```

These messages come from haskell itself and are false positives in most cases (unless the elm compiler actually does something wrong), also there are meant for the developers of the application, not the users.

See https://ghc.haskell.org/trac/ghc/ticket/12495
