### PR TITLE
Only copy `.elm` files, `elm-package.json`, and `elm-stuff` of the pr…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.17.8
+* Only copy `.elm` files, `elm-package.json`, and `elm-stuff` of the project directory to the work directory.
+* If `Lint On The Fly` is enabled, force a lint when a `.elm` file is deleted.
+
 ## 0.17.7
 * If `Lint On The Fly` is enabled or `Work Directory` is set, do not lint if there is a source directory outside the project directory.
 

--- a/lib/linter-elm-make.js
+++ b/lib/linter-elm-make.js
@@ -442,9 +442,13 @@ export default {
         // TODO Check if `sourceDirectories` is an array of strings.
         const sourceDirectories = json['source-directories'];
         if (sourceDirectories && sourceDirectories.length > 0) {
-          const copyOptionsWithFilter = JSON.parse(JSON.stringify(copyOptions));
-          copyOptionsWithFilter.filter = (filePath) => {
-            return !filePath.startsWith(workDirectory + path.sep);
+          const copyOptionsWithElmFilter = JSON.parse(JSON.stringify(copyOptions));
+          copyOptionsWithElmFilter.filter = (filePath) => {
+            return path.extname(filePath) === '.elm';
+          };
+          const copyOptionsWithElmAndDirectoryFilter = JSON.parse(JSON.stringify(copyOptions));
+          copyOptionsWithElmAndDirectoryFilter.filter = (filePath) => {
+            return !filePath.startsWith(workDirectory + path.sep) && copyOptionsWithElmFilter.filter(filePath);
           };
           // Filter out child source directories (i.e. if a source directory is inside another, do not copy files for that source directory anymore).
           const allSourceDirectories = sourceDirectories.map(x => path.resolve(projectDirectory, x));
@@ -462,10 +466,10 @@ export default {
                 const projectFilePaths = readDir.readSync(projectSourceDirectory, null, readDir.ABSOLUTE_PATHS);
                 projectFilePaths.forEach((projectFilePath) => {
                   const workFilePath = projectFilePath.replace(projectDirectory, workDirectory);
-                  fs.copySync(projectFilePath, workFilePath, copyOptionsWithFilter);
+                  fs.copySync(projectFilePath, workFilePath, copyOptionsWithElmAndDirectoryFilter);
                 });
               } else {
-                fs.copySync(projectSourceDirectory, workSourceDirectory, copyOptions);
+                fs.copySync(projectSourceDirectory, workSourceDirectory, copyOptionsWithElmFilter);
               }
               if (atom.config.get('linter-elm-make.logDebugMessages')) {
                 if (fs.existsSync(workSourceDirectory)) {
@@ -523,6 +527,10 @@ export default {
       devLog('`unlink` detected - ' + filePath);
       if (!filePath.startsWith(workDirectory + path.sep)) {
         fs.removeSync(path.join(workDirectory, filename));
+        // TODO Only force lint if active editor is inside `projectDirectory`.
+        if (atom.config.get('linter-elm-make.lintOnTheFly')) {
+          forceLintActiveElmEditor();
+        }
       }
     });
     watcher.on('unlinkDir', (dirname) => {


### PR DESCRIPTION
…oject directory to the work directory; If `Lint On The Fly` is enabled, force a lint when a `.elm` file is deleted