### PR TITLE
Native modules are copied to working directory

### DIFF
--- a/lib/linter-elm-make.js
+++ b/lib/linter-elm-make.js
@@ -522,10 +522,7 @@ export default {
           copyOptionsWithElmFilter.filter = (filePath) => {
             // if filePath is an elm src file (`src/*.elm`) or a native src file (`src/Native/*.js`)
             return path.extname(filePath) === '.elm' ||
-              (nativeModules &&
-               path.dirname(filePath).split(path.sep).includes('Native') &&
-               path.extname(filePath) === '.js'
-              );
+              (nativeModules && isNativeSrcFile(filePath));
           };
           const copyOptionsWithElmAndDirectoryFilter = JSON.parse(JSON.stringify(copyOptions));
           copyOptionsWithElmAndDirectoryFilter.filter = (filePath) => {
@@ -573,8 +570,7 @@ export default {
       ignored.push(workDirectory.replace(projectDirectory + path.sep, '') + path.sep + '**');
     }
     // TODO Only watch source directories.
-    // TODO watch native modules
-    let watcher = chokidar.watch(['elm-package.json', 'elm-stuff/exact-dependencies.json', 'elm-stuff/packages/**', '**/*.elm'], {
+    let watcher = chokidar.watch(['elm-package.json', 'elm-stuff/exact-dependencies.json', 'elm-stuff/packages/**', '**/*.elm', '**/Native/**/*.js'], {
       cwd: projectDirectory,
       usePolling: true, useFsEvents: true, persistent: true,
       ignored: ignored, ignoreInitial: true,
@@ -585,13 +581,21 @@ export default {
     this.watchers[projectDirectory] = watcher;
     watcher.on('add', (filename) => {
       const filePath = path.join(projectDirectory, filename);
-      if (!filePath.startsWith(workDirectory + path.sep) &&
-        (filePath === path.join(projectDirectory, 'elm-package.json') ||
-         filePath === path.join(projectDirectory, 'elm-stuff', 'exact-dependencies.json') ||
-         filePath.startsWith(path.join(projectDirectory, 'elm-stuff', 'packages')) ||
-         path.extname(filePath) === '.elm')) {
-         helper.devLog('`add` detected - ' + filePath);
-        fs.copySync(filePath, path.join(workDirectory, filename));
+      if (!filePath.startsWith(workDirectory + path.sep)) {
+        if (filePath === path.join(projectDirectory, 'elm-package.json') ||
+            filePath === path.join(projectDirectory, 'elm-stuff', 'exact-dependencies.json') ||
+            filePath.startsWith(path.join(projectDirectory, 'elm-stuff', 'packages')) ||
+            path.extname(filePath) === '.elm') {
+          helper.devLog('`add` detected - ' + filePath);
+          fs.copySync(filePath, path.join(workDirectory, filename));
+        } else if (isNativeSrcFile(filePath)) {
+          // only load `elm-package.json` if a native file is added
+          const json = fs.readJsonSync(path.join(projectDirectory, 'elm-package.json'), {throws: false});
+          if (json['native-modules']) {
+            helper.devLog('`add` detected (native src file) - ' + filePath);
+            fs.copySync(filePath, path.join(workDirectory, filename));
+          }
+        }
       }
     });
     // watcher.on('addDir', (filename) => {
@@ -1104,6 +1108,11 @@ function getProjectBuildArtifactsDirectory(filePath) {
     });
   }
   return null;
+}
+
+function isNativeSrcFile(filePath) {
+  return path.dirname(filePath).split(path.sep).includes('Native') &&
+         path.extname(filePath) === '.js';
 }
 
 function isASourceDirectoryOutsideProjectDirectory(projectDirectory) {

--- a/lib/linter-elm-make.js
+++ b/lib/linter-elm-make.js
@@ -519,7 +519,7 @@ export default {
         if (sourceDirectories && sourceDirectories.length > 0) {
           const copyOptionsWithElmFilter = JSON.parse(JSON.stringify(copyOptions));
           copyOptionsWithElmFilter.filter = (filePath) => {
-            return path.extname(filePath) === '.elm';
+            return path.extname(filePath) === '.elm' || path.dirname(filePath).split(path.sep).includes('Native');
           };
           const copyOptionsWithElmAndDirectoryFilter = JSON.parse(JSON.stringify(copyOptions));
           copyOptionsWithElmAndDirectoryFilter.filter = (filePath) => {

--- a/lib/linter-elm-make.js
+++ b/lib/linter-elm-make.js
@@ -517,9 +517,15 @@ export default {
         // TODO Check if `sourceDirectories` is an array of strings.
         const sourceDirectories = json['source-directories'];
         if (sourceDirectories && sourceDirectories.length > 0) {
+          const nativeModules = json['native-modules'];
           const copyOptionsWithElmFilter = JSON.parse(JSON.stringify(copyOptions));
           copyOptionsWithElmFilter.filter = (filePath) => {
-            return path.extname(filePath) === '.elm' || path.dirname(filePath).split(path.sep).includes('Native');
+            // if filePath is an elm src file (`src/*.elm`) or a native src file (`src/Native/*.js`)
+            return path.extname(filePath) === '.elm' ||
+              (nativeModules &&
+               path.dirname(filePath).split(path.sep).includes('Native') &&
+               path.extname(filePath) === '.js'
+              );
           };
           const copyOptionsWithElmAndDirectoryFilter = JSON.parse(JSON.stringify(copyOptions));
           copyOptionsWithElmAndDirectoryFilter.filter = (filePath) => {
@@ -567,6 +573,7 @@ export default {
       ignored.push(workDirectory.replace(projectDirectory + path.sep, '') + path.sep + '**');
     }
     // TODO Only watch source directories.
+    // TODO watch native modules
     let watcher = chokidar.watch(['elm-package.json', 'elm-stuff/exact-dependencies.json', 'elm-stuff/packages/**', '**/*.elm'], {
       cwd: projectDirectory,
       usePolling: true, useFsEvents: true, persistent: true,


### PR DESCRIPTION
Problem (#122):
When using "Lint On The Fly", native modules were not copied to the working directory resulting in "Package not found" linting errors even when elm-make ran successfully.

Solution:
Expanded the rules for copying files to include anything in a `Native` directory