### PR TITLE
Make timeout a configurable option

### DIFF
--- a/lib/config.js
+++ b/lib/config.js
@@ -55,5 +55,12 @@ export default {
     type: 'boolean',
     default: false,
     order: 8
+  },
+  timeout: {
+    title: 'Timeout',
+    description: 'Kill the linter process if it takes longer than this (in seconds) (`0` = disabled)',
+    type: 'integer',
+    default: 10,
+    order: 9
   }
 };

--- a/lib/linter-elm-make.js
+++ b/lib/linter-elm-make.js
@@ -814,10 +814,12 @@ export default {
     }
     let self = this;
     helper.devLog('Executing ' + executablePath + ' ' + args.join(' ') + ' (initiated from ' + editorFilePath + ')');
+    var timeout = (parseFloat(atom.config.get('linter-elm-make.timeout')) || 10) * 1000;
     return atomLinter.exec(executablePath, args, {
       stream: 'both', // stdout and stderr
       cwd: cwd,
-      env: process.env
+      env: process.env,
+      timeout: timeout
     })
     .then(data => {
       self.clearElmEditorProblemsAndFixes(editor);


### PR DESCRIPTION
A default 10 second timeout was added in https://github.com/steelbrain/atom-linter/commit/8096e6bfc5576567044259ea3f1610140129cc7e that kills the linter process if it takes longer than 10 seconds to run.
The problem is, some large elm files take a lot longer than 10 seconds to lint. This option lets the user set a custom timeout to enable the linting of large files.

Fixes #147.