### PR TITLE
Fix timeout option

### DIFF
--- a/lib/config.js
+++ b/lib/config.js
@@ -59,7 +59,7 @@ export default {
   timeout: {
     title: 'Timeout',
     description: 'Kill the linter process if it takes longer than this (in seconds) (`0` = disabled)',
-    type: 'integer',
+    type: 'number',
     default: 10,
     order: 9
   }

--- a/lib/linter-elm-make.js
+++ b/lib/linter-elm-make.js
@@ -814,7 +814,8 @@ export default {
     }
     let self = this;
     helper.devLog('Executing ' + executablePath + ' ' + args.join(' ') + ' (initiated from ' + editorFilePath + ')');
-    var timeout = (parseFloat(atom.config.get('linter-elm-make.timeout')) || 10) * 1000;
+    var timeoutConfig = parseFloat(atom.config.get('linter-elm-make.timeout'));
+    var timeout = (isNaN(timeoutConfig) ? 10 : timeoutConfig) * 1000;
     return atomLinter.exec(executablePath, args, {
       stream: 'both', // stdout and stderr
       cwd: cwd,


### PR DESCRIPTION
The previous implementation (#148) used the 10 second default value if you specified a value of `0`.
This PR fixes the issue and allows you to specify a value of `0`.

Although one thing I have noticed; if you set the value of `timeout` to `0` (zero) in the settings view, while Atom does store the `0` correctly (`atom.config.get('linter-elm-make.timeout')` does equal `0`), it doesnt appear in the settings view. It just shows the 'default' placeholder. This is probably a bug in [atom/settings-view](https://github.com/atom/settings-view).

_View when value is set to `0`_:
![image](https://user-images.githubusercontent.com/2421069/29887991-31352dca-8db7-11e7-81d9-2f96a76ba823.png)

I've reported the zero value bug here: https://github.com/atom/settings-view/issues/985
